### PR TITLE
Add Docker build instructions, enabling Mac / Windows users to compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      autoconf \
+      automake \
+      libtool \
+      pkg-config \
+      make \
+      python3 \
+      ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Toolchain is expected to be mounted at /opt/mini from the host.
+# Example: -v /path/to/mini_toolchain-v1.0/mini:/opt/mini
+
+WORKDIR /work

--- a/README.md
+++ b/README.md
@@ -26,18 +26,27 @@ SDL2_mixer-2.6.3.tar.gz
 $ cd
 $ wget https://github.com/steward-fu/website/releases/download/miyoo-mini/mini_toolchain-v1.0.tar.gz
 $ tar xvf mini_toolchain-v1.0.tar.gz
-$ sudo mini /opt
 
 $ git clone https://github.com/steward-fu/sdl2
 $ cd sdl2
-$ make cfg
 
-$ make gpu
+# Build inside Docker (macOS-friendly)
+$ docker build --platform linux/amd64 -t miyoo-sdl2 .
+$ docker run --rm --platform linux/amd64 \
+    -v /path/to/sdl2:/work \
+    -v /path/to/mini_toolchain-v1.0/mini:/opt/mini \
+    -v /path/to/mini_toolchain-v1.0/prebuilt:/opt/prebuilt \
+    -w /work miyoo-sdl2 bash -lc "\
+    ln -sf /opt/prebuilt/arm-linux-gnueabihf/bin/ld.bfd /opt/prebuilt/arm-linux-gnueabihf/bin/ld; \
+    ln -sf /opt/prebuilt/arm-linux-gnueabihf/bin/ld.bfd /opt/prebuilt/bin/arm-linux-gnueabihf-ld; \
+    ln -sf /opt/prebuilt/arm-linux-gnueabihf/bin/ld.bfd /opt/prebuilt/bin/arm-linux-gnueabihf-ld.bfd; \
+    export PATH=/opt/prebuilt/arm-linux-gnueabihf/bin:/opt/prebuilt/bin:/opt/mini/bin:$PATH; \
+    make cfg && make gpu && make sdl2"
+
 $ ls swiftshader/build/lib*
     swiftshader/build/libEGL.so
     swiftshader/build/libGLESv2.so
 
-$ make sdl2
 $ ls sdl2/build/.libs/libSDL2-2.0.so.0*
     sdl2/build/.libs/libSDL2-2.0.so.0
     sdl2/build/.libs/libSDL2-2.0.so.0.18.2


### PR DESCRIPTION
Add a Dockerfile and update the README with a Docker-based build flow for macOS/Linux hosts, including toolchain mount points and ld symlink fixes.